### PR TITLE
Center conditions card and use placeholders for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     .info-condiciones {
       background: var(--lila-base);
       border-radius: 1rem;
-      margin: 2.5rem 0 0 0; padding: 2rem;
+      margin: 2.5rem auto 0; padding: 2rem;
       box-shadow: 0 4px 24px rgba(180,150,255,0.05);
       font-size: 1.12rem;
     }
@@ -135,7 +135,7 @@
 </head>
 <body>
   <nav class="navbar">
-    <a href="#"><img src="logo-dulzuras-magicas.png" alt="Logo Dulzuras Mágicas" /></a>
+    <a href="#"><img src="https://placehold.co/48x48?text=Logo" alt="Logo Dulzuras Mágicas" /></a>
     <ul>
       <li><a href="#productos">Productos</a></li>
       <li><a href="#condiciones">Condiciones</a></li>
@@ -156,7 +156,7 @@
     <div class="productos-categorias">
       <!-- TORTAS -->
       <div class="categoria">
-        <img src="torta-placeholder.jpg" alt="Torta artesanal" />
+        <img src="https://placehold.co/90x90?text=Torta" alt="Torta artesanal" />
         <h3>Tortas</h3>
         <ul>
           <li>Lemon Pie <span class="precio">$39.000</span></li>
@@ -170,7 +170,7 @@
       </div>
       <!-- MASAS SECAS Y BOMBONES -->
       <div class="categoria">
-        <img src="masas-secas-placeholder.jpg" alt="Masas secas y bombones" />
+        <img src="https://placehold.co/90x90?text=Masas" alt="Masas secas y bombones" />
         <h3>Masas secas y bombones</h3>
         <ul>
           <li>Masas secas 1kg <span class="precio">$56.000</span></li>
@@ -182,7 +182,7 @@
       </div>
       <!-- ALFAJORES Y BUDINES -->
       <div class="categoria">
-        <img src="alfajor-placeholder.jpg" alt="Alfajores y budines" />
+        <img src="https://placehold.co/90x90?text=Alfajor" alt="Alfajores y budines" />
         <h3>Alfajores y Budines</h3>
         <ul>
           <li>Alfajor de maicena x unidad <span class="precio">$4.500</span></li>


### PR DESCRIPTION
## Summary
- center the conditions section on desktop view
- swap missing images for external placeholder images

## Testing
- `npx -y htmlhint index.html`
- `npx prettier --check index.html` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bd30b9fc8331931d170bc6bb0aab